### PR TITLE
Add delete_event script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+- Build: `cargo build`
+- Run: `cargo run`
+- Test all: `cargo test`
+- Test single: `cargo test test_name`
+- Test specific crate: `cargo test -p crates_name`
+- Lint: `cargo clippy`
+- Format: `cargo fmt`
+- Frontend dev: `cd frontend && npm run dev`
+- Frontend build: `cd frontend && npm run build`
+
+## Code Style Guidelines
+- Rust: Follow standard Rust conventions (use rustfmt & clippy)
+- Use error handling with anyhow/thiserror/snafu for propagation
+- Type safety: Prefer strong typing with proper error types
+- Use async/await with Tokio for async operations
+- Imports: Group standard library, external crates, and internal modules
+- Naming: snake_case for variables/functions, CamelCase for types
+- TypeScript: Use type annotations for all exports
+- Structure code with modules and clear separation of concerns
+- Use middleware pattern for request processing
+- Test all public functionality
+
+## Important Notes
+- Always import Nostr types from `nostr_sdk::prelude::*` 
+- Never import directly from `nostr` package
+- This is a Nostr groups relay implementing NIP-29 group management
+
+## NIP-29 Implementation
+This project implements the [NIP-29 Relay-Based Groups](https://github.com/nostr-protocol/nips/blob/master/29.md) specification with these key components:
+
+### Key Event Kinds
+- Group management (9000-9020): Add/remove users, edit metadata, delete events
+- User events (9021-9022): Join/leave requests
+- Group metadata (39000): Define name, picture, description, visibility
+- Group state (39001-39003): Admins list, members list, supported roles
+
+### Group Features
+- Public/private visibility: Control read access
+- Open/closed access: Auto-accept vs. manual approval for joins
+- Broadcast mode: Only admins can post content
+- Role-based access control: Admin/member privileges
+
+### Tag Types
+- `h` tag: Required for group identification
+- `d` tag: Used for addressable event kinds in the 39xxx range

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,3 +21,4 @@ ignore:
   - "**/*_test.rs"
   - "**/*.test.rs"
   - "**/tests/**"
+  - "**/bin/delete_event.rs"

--- a/crates/groups_relay/src/bin/delete_event.rs
+++ b/crates/groups_relay/src/bin/delete_event.rs
@@ -1,0 +1,80 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use nostr_database::{NostrEventsDatabase};
+use nostr_sdk::prelude::*;
+use nostr_lmdb::NostrLMDB;
+use std::path::PathBuf;
+use tracing::{error, info};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "delete-event",
+    version = "0.1.0",
+    about = "Deletes a specific Nostr event from the LMDB database."
+)]
+struct Args {
+    /// Hex-encoded ID of the Nostr event to delete.
+    #[arg(short, long)]
+    event_id: String,
+
+    /// Path to the LMDB database directory.
+    #[arg(short, long)]
+    db: PathBuf,
+}
+
+fn setup_tracing() {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,delete_event=debug"));
+
+    fmt()
+        .with_env_filter(env_filter)
+        .with_timer(fmt::time::SystemTime)
+        .with_target(true)
+        .with_thread_ids(false)
+        .with_thread_names(false)
+        .with_file(false)
+        .with_line_number(false)
+        .with_level(true)
+        .init();
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    setup_tracing();
+    let args = Args::parse();
+
+    // Parse the event ID
+    let event_id = EventId::from_hex(&args.event_id)
+        .with_context(|| format!("Invalid event ID format: {}", args.event_id))?;
+
+    info!(
+        "Attempting to delete event ID {} from database at {:?}",
+        event_id.to_hex(),
+        args.db
+    );
+
+    // Open the database
+    let db = NostrLMDB::open(&args.db)
+        .with_context(|| format!("Failed to open database at {:?}", args.db))?;
+
+    // Create the filter
+    let filter = Filter::new().id(event_id);
+
+    // Delete the event
+    match db.delete(filter).await {
+        Ok(_) => {
+            info!(
+                "Successfully deleted event {} from database {:?}.",
+                event_id.to_hex(),
+                args.db
+            );
+            Ok(())
+        }
+        Err(e) => {
+            error!("Failed to delete event {}: {:?}", event_id.to_hex(), e);
+            Err(e.into())
+        }
+    }
+}

--- a/crates/groups_relay/src/groups/group.rs
+++ b/crates/groups_relay/src/groups/group.rs
@@ -1,7 +1,6 @@
 use crate::error::Error;
 use crate::StoreCommand;
-use nostr::prelude::*;
-use nostr::{Tag, TagKind};
+use nostr_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
@@ -1420,8 +1419,6 @@ mod tests {
         create_test_invite_event, create_test_keys, create_test_metadata_event,
         create_test_role_event, remove_member_from_group,
     };
-    use pretty_assertions::assert_eq;
-
     #[tokio::test]
     async fn test_group_creation() {
         let (admin_keys, _, _) = create_test_keys().await;

--- a/docs/broadcast_groups_plan.md
+++ b/docs/broadcast_groups_plan.md
@@ -1,0 +1,36 @@
+# Plan: Implement Broadcast-Only NIP-29 Groups
+
+This plan outlines the steps required to implement a feature allowing NIP-29 groups to operate in a broadcast-only mode, where only Admins can publish standard content events. We will start by writing a failing test.
+
+## Tasks
+
+-   [x] **1. Add Test for Broadcast Mode Publishing Restrictions:**
+    -   Location: `mod tests` in `crates/groups_relay/src/groups/group.rs`.
+    -   Create a new test function (e.g., `test_broadcast_mode_restrictions`).
+    -   Scenario 1: Broadcast Mode Enabled
+        -   Setup: Create a group, add a member. Update metadata via `kind:39000` or `kind:9002` to include the `["broadcast"]` tag.
+        -   Test Admin Publishing: Create a standard event (e.g., `Kind::TextNote`) signed by the Admin. Assert that publishing succeeds.
+        -   Test Member Publishing (Blocked): Create a standard event signed by the Member. Assert that publishing fails with `Error::restricted`.
+        -   Test Member Publishing (Allowed): Create `kind:9021` (Join) and `kind:9022` (Leave) events signed by the Member. Assert that publishing succeeds for these specific kinds.
+    -   Scenario 2: Broadcast Mode Disabled (Default)
+        -   Setup: Create a group and add a member, ensuring the `["broadcast"]` tag is *not* present in metadata.
+        -   Test Member Publishing: Create a standard event signed by the Member. Assert that publishing succeeds.
+    -   Scenario 3: Disabling Broadcast Mode
+        -   Setup: Create a group, enable broadcast mode via `kind:9002` with the `["broadcast"]` tag. Then send another `kind:9002` *without* the `["broadcast"]` tag.
+        -   Test Member Publishing: Create a standard event signed by the Member. Assert that publishing now succeeds.
+
+-   [x] **2. Modify `GroupMetadata` Struct:**
+    -   Location: `crates/groups_relay/src/groups/group.rs`
+    -   Add a new boolean field, `is_broadcast: bool`, initialized to `false`.
+-   [x] **3. Update Metadata Parsing:**
+    -   `Group::load_metadata_from_event` (for `kind:39000`): Modify parsing to look for the `["broadcast"]` tag and set `is_broadcast` accordingly.
+    -   `Group::set_metadata` (for `kind:9002`): Modify parsing. Check for the presence of the `["broadcast"]` tag *within the incoming event*. If present, set `self.metadata.is_broadcast = true`. If *absent*, explicitly set `self.metadata.is_broadcast = false`.
+-   [x] **4. Update Metadata Generation:**
+    -   Location: `Group::generate_metadata_event` in `crates/groups_relay/src/groups/group.rs`.
+    -   Modify the event generation to include the `["broadcast"]` tag if `self.metadata.is_broadcast` is `true`.
+-   [x] **5. Enforce Publishing Restrictions:**
+    -   Location: `Group::handle_group_content` (or identified validation point).
+    -   Add logic: `if self.metadata.is_broadcast && !self.is_admin(&event.pubkey) && ![KIND_GROUP_USER_JOIN_REQUEST_9021, KIND_GROUP_USER_LEAVE_REQUEST_9022].contains(&event.kind)`.
+    -   If the condition is true, reject the event with `Error::restricted`.
+-   [x] **6. Update Existing Tests (If Necessary):**
+    -   Review existing tests for regressions.


### PR DESCRIPTION
Adds a delete command to be able to delete events directly from the db 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line tool for deleting specific Nostr events from the database.
- **Documentation**
	- Added a comprehensive guide for AI code contributions, including style and project-specific guidelines.
	- Introduced a detailed implementation plan for broadcast-only mode in NIP-29 groups.
- **Refactor**
	- Updated imports to use a consistent source for Nostr types, improving code clarity.
- **Chores**
	- Removed unnecessary test dependencies from imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->