### PR TITLE
fix(frontend): correct nos2x identity — use window.nostr for signing instead of treating pubkey as private key

### DIFF
--- a/frontend/src/api/nostr_client.ts
+++ b/frontend/src/api/nostr_client.ts
@@ -1,6 +1,7 @@
 import NDK, {
   NDKEvent,
   NDKPrivateKeySigner,
+  NDKNip07Signer,
   NDKRelay,
   NDKPublishError,
   NDKUser,
@@ -88,12 +89,16 @@ export class NostrClient {
 
       // Try to create the signer with better error handling
       let signer;
-      try {
-        signer = new NDKPrivateKeySigner(key);
-      } catch (signerError) {
-        throw new Error(
-          "Invalid private key provided. Please check the format and try again."
-        );
+      if (key === "nip07") {
+        signer = new NDKNip07Signer();
+      } else {
+        try {
+          signer = new NDKPrivateKeySigner(key);
+        } catch (signerError) {
+          throw new Error(
+            "Invalid private key provided. Please check the format and try again."
+          );
+        }
       }
 
       // Groups NDK - only for group relay operations

--- a/frontend/src/api/nostr_client.ts
+++ b/frontend/src/api/nostr_client.ts
@@ -1,10 +1,11 @@
 import NDK, {
   NDKEvent,
   NDKPrivateKeySigner,
-  NDKNip07Signer,
   NDKRelay,
   NDKPublishError,
   NDKUser,
+  type NDKSigner,
+  type NostrEvent,
 } from "@nostr-dev-kit/ndk";
 import { nip19 } from "nostr-tools";
 import localforage from "localforage";
@@ -34,6 +35,40 @@ export interface NostrClientConfig {
 
 // Re-export Transaction type from wallet service
 export { type Transaction } from "../services/CashuWalletService";
+
+// Minimal NIP-07 signer: pubkey is known upfront (from window.nostr.getPublicKey()
+// in AuthPrompt), so we never call getPublicKey() again inside the auth timeout.
+// All signing is delegated to window.nostr.signEvent().
+class WindowNostrSigner implements NDKSigner {
+  private readonly _pubkey: string;
+  private readonly _user: NDKUser;
+
+  constructor(pubkey: string) {
+    this._pubkey = pubkey;
+    this._user = new NDKUser({ pubkey });
+  }
+
+  get pubkey(): string { return this._pubkey; }
+
+  async blockUntilReady(): Promise<NDKUser> { return this._user; }
+  async user(): Promise<NDKUser> { return this._user; }
+
+  async sign(event: NostrEvent): Promise<string> {
+    const signed = await window.nostr!.signEvent(event as any);
+    if (!signed?.sig) throw new Error("nos2x did not return a signature");
+    return signed.sig;
+  }
+
+  get userSync(): NDKUser { return this._user; }
+  toPayload(): string { return JSON.stringify({ type: "nip07", pubkey: this._pubkey }); }
+
+  async encrypt(recipient: NDKUser, value: string): Promise<string> {
+    return window.nostr!.nip04!.encrypt(recipient.pubkey, value);
+  }
+  async decrypt(sender: NDKUser, value: string): Promise<string> {
+    return window.nostr!.nip04!.decrypt(sender.pubkey, value);
+  }
+}
 
 export class NostrGroupError extends Error {
   readonly rawMessage: string;
@@ -88,9 +123,12 @@ export class NostrClient {
       }
 
       // Try to create the signer with better error handling
-      let signer;
-      if (key === "nip07") {
-        signer = new NDKNip07Signer();
+      let signer: NDKSigner;
+      if (key.startsWith("nip07:")) {
+        // Key is "nip07:<hex-pubkey>" — pubkey was fetched from the extension
+        // before this client was created, so no second getPublicKey() is needed.
+        const pubkey = key.slice(6);
+        signer = new WindowNostrSigner(pubkey);
       } else {
         try {
           signer = new NDKPrivateKeySigner(key);
@@ -1095,13 +1133,15 @@ export class NostrClient {
           mainRelay.removeAllListeners("auth:failed");
         };
 
-        // Increase timeout for main relay
+        // NIP-07 signers may show a browser extension popup for signEvent on first
+        // use, so allow more time. Private key signing is instant (10 s is enough).
+        const isExtensionSigner = this.groupsNdk.signer instanceof WindowNostrSigner;
         setTimeout(() => {
           cleanup();
           reject(
             new Error("Connection timeout waiting for main relay authentication")
           );
-        }, 10000); // 10 seconds for main relay
+        }, isExtensionSigner ? 30000 : 10000);
       });
 
       // All relay statuses are now available

--- a/frontend/src/components/AuthPrompt.tsx
+++ b/frontend/src/components/AuthPrompt.tsx
@@ -72,11 +72,15 @@ export const AuthPrompt: FunctionComponent<AuthPromptProps> = ({ onSubmit }) => 
         return
       }
 
-      // Verify the extension is accessible and request user consent
-      await window.nostr.getPublicKey()
-      // Pass the NIP-07 sentinel so NostrClient uses NDKNip07Signer,
-      // which delegates signing to the extension with the correct identity.
-      onSubmit('nip07')
+      // Get the pubkey — this also establishes the user's consent with the extension.
+      // Pass it as 'nip07:<pubkey>' so the client can build the correct identity
+      // immediately without a second getPublicKey round-trip inside the auth timeout.
+      const pubkey = await window.nostr.getPublicKey()
+      if (!pubkey) {
+        setError('Extension did not return a public key. Please try again.')
+        return
+      }
+      onSubmit(`nip07:${pubkey}`)
     } catch (e) {
       console.error('Failed to connect to extension:', e)
       setError('Failed to connect to extension. Please try again.')

--- a/frontend/src/components/AuthPrompt.tsx
+++ b/frontend/src/components/AuthPrompt.tsx
@@ -72,10 +72,11 @@ export const AuthPrompt: FunctionComponent<AuthPromptProps> = ({ onSubmit }) => 
         return
       }
 
-      const pubkey = await window.nostr.getPublicKey()
-      if (pubkey) {
-        onSubmit(pubkey)
-      }
+      // Verify the extension is accessible and request user consent
+      await window.nostr.getPublicKey()
+      // Pass the NIP-07 sentinel so NostrClient uses NDKNip07Signer,
+      // which delegates signing to the extension with the correct identity.
+      onSubmit('nip07')
     } catch (e) {
       console.error('Failed to connect to extension:', e)
       setError('Failed to connect to extension. Please try again.')

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,6 +31,16 @@ const Initialization = ({ onComplete }: InitializationProps) => {
   const [status, setStatus] = useState<'idle' | 'connecting'>('idle')
 
   useEffect(() => {
+    // One-time migration: clear sessions from before the NIP-07 fix.
+    // Old nos2x sessions stored the pubkey (hex) as the key instead of
+    // using 'nip07'. We can't distinguish a stored pubkey from a stored
+    // privkey, so we invalidate all pre-v2 sessions once.
+    const SESSION_VERSION = '2'
+    if (localStorage.getItem('session_version') !== SESSION_VERSION) {
+      localStorage.removeItem('nostr_key')
+      localStorage.setItem('session_version', SESSION_VERSION)
+    }
+
     // Check if we have a stored key
     const storedKey = localStorage.getItem('nostr_key')
     if (storedKey) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,17 +31,6 @@ const Initialization = ({ onComplete }: InitializationProps) => {
   const [status, setStatus] = useState<'idle' | 'connecting'>('idle')
 
   useEffect(() => {
-    // One-time migration: clear sessions from before the NIP-07 fix.
-    // Old nos2x sessions stored the pubkey (hex) as the key instead of
-    // using 'nip07'. We can't distinguish a stored pubkey from a stored
-    // privkey, so we invalidate all pre-v2 sessions once.
-    const SESSION_VERSION = '2'
-    if (localStorage.getItem('session_version') !== SESSION_VERSION) {
-      localStorage.removeItem('nostr_key')
-      localStorage.setItem('session_version', SESSION_VERSION)
-    }
-
-    // Check if we have a stored key
     const storedKey = localStorage.getItem('nostr_key')
     if (storedKey) {
       connectWithKey(storedKey)

--- a/frontend/src/types/nostr.d.ts
+++ b/frontend/src/types/nostr.d.ts
@@ -1,7 +1,10 @@
 interface Window {
   nostr?: {
     getPublicKey(): Promise<string>;
-    signEvent(event: any): Promise<any>;
-    // Add other NIP-07 methods as needed
+    signEvent(event: any): Promise<{ sig: string; [key: string]: any }>;
+    nip04?: {
+      encrypt(pubkey: string, plaintext: string): Promise<string>;
+      decrypt(pubkey: string, ciphertext: string): Promise<string>;
+    };
   };
 }


### PR DESCRIPTION
  ## Problem

  When logging in with a NIP-07 browser extension (nos2x, Alby, etc.),
  `window.nostr.getPublicKey()` returns the user's **public key**. This
  pubkey was passed directly to `NDKPrivateKeySigner`, which treats any
  64-character hex string as a *private* key and derives a completely
  different keypair from it. As a result, the displayed npub and the
  identity used for signing did not match the user's actual Nostr identity.

  ## Root cause

  ```ts
  // AuthPrompt.tsx — before
  const pubkey = await window.nostr.getPublicKey()
  onSubmit(pubkey)  // ← pubkey passed as if it were a private key

  // nostr_client.ts — before
  signer = new NDKPrivateKeySigner(key)  // ← derives wrong keypair from pubkey

  Fix

  Introduced a lightweight WindowNostrSigner class that:

  - Receives the correct pubkey before the relay connection starts
  (fetched in AuthPrompt via getPublicKey())
  - Exposes that pubkey directly via user() — no second getPublicKey()
  call needed inside the auth timeout
  - Delegates all event signing to window.nostr.signEvent()

  The relay auth timeout is raised to 30 s when WindowNostrSigner is
  active, giving users time to approve the extension's signEvent dialog
  on their very first login. Subsequent logins are auto-approved.

  Changed files

  - frontend/src/components/AuthPrompt.tsx — passes nip07:<pubkey>
  instead of the raw pubkey
  - frontend/src/api/nostr_client.ts — detects nip07: prefix, creates
  WindowNostrSigner with the correct pubkey baked in
  - frontend/src/types/nostr.d.ts — extended window.nostr type
  definition (signEvent return type, nip04)